### PR TITLE
feat: upgrade Ubuntu 24.04 & checkout v6 & flyctl 0.3.226

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,23 +5,31 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: actions/checkout@v6
         with:
-          version: 0.3.40
+          fetch-depth: 1
+      - uses: superfly/flyctl-actions/setup-flyctl@1.5
+        with:
+          version: 0.3.226
       - name: prepare secrets
+        run: |
+          grep -v ^\# < .secrets >> $GITHUB_ENV
+      - name: override secrets
         env:
           SECRETS: "${{ toJSON(secrets) }}"
         run: |
-          grep -v ^\# < .secrets >> $GITHUB_ENV
           echo "$SECRETS" | jq -r 'keys[] as $k | "\($k)=\(.[$k])"' >> $GITHUB_ENV
       - name: create app
-        run: flyctl apps create --name $FLY_APP 2>/dev/null || true
+        run: |
+          flyctl apps create --name $FLY_APP 2>/dev/null || true
       - name: create volume
-        run: flyctl volume create vaultwarden -y -n 1 -r $FLY_REGION 2>/dev/null || true
+        run: |
+          flyctl volume create vaultwarden -y -n 1 -r $FLY_REGION 2>/dev/null || true
       - name: exports secrets
-        run: env | grep ^APP_ | sed 's/^APP_//g' | flyctl secrets import --stage
+        run: |
+          env | grep ^APP_ | sed 's/^APP_//g' | flyctl secrets import --stage
       - name: deploy app
-        run: flyctl deploy --yes --remote-only --regions $FLY_REGION
+        run: |
+          flyctl deploy --yes --remote-only


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade deploy workflow to Ubuntu 24.04 with checkout v6 and flyctl 0.3.226, and switch project indent size to 2 spaces.
> 
> - **CI/CD – `/.github/workflows/deploy.yml`**:
>   - **Runners & actions**: Update runner to `ubuntu-24.04`; bump `actions/checkout` to `v6` (with `fetch-depth: 1`); bump `superfly/flyctl-actions/setup-flyctl` to `1.5` with `version: 0.3.226`.
>   - **Secrets & steps**: Split secrets into separate "prepare" and "override" steps; use environment export/import; convert commands to multiline blocks.
>   - **Deploy command**: remove `--regions $FLY_REGION` from `flyctl deploy --remote-only`.
> - **EditorConfig – `/.editorconfig`**: Set `indent_size` to `2` (was `4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01aa0fee3634e5261cb6198e0df8220c94b6e132. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->