### PR TITLE
chore: update Litestream image to version 0.5.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,23 +5,31 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: actions/checkout@v6
         with:
-          version: 0.3.40
+          fetch-depth: 1
+      - uses: superfly/flyctl-actions/setup-flyctl@1.5
+        with:
+          version: 0.3.226
       - name: prepare secrets
+        run: |
+          grep -v ^\# < .secrets >> $GITHUB_ENV
+      - name: override secrets
         env:
           SECRETS: "${{ toJSON(secrets) }}"
         run: |
-          grep -v ^\# < .secrets >> $GITHUB_ENV
           echo "$SECRETS" | jq -r 'keys[] as $k | "\($k)=\(.[$k])"' >> $GITHUB_ENV
       - name: create app
-        run: flyctl apps create --name $FLY_APP 2>/dev/null || true
+        run: |
+          flyctl apps create --name $FLY_APP 2>/dev/null || true
       - name: create volume
-        run: flyctl volume create vaultwarden -y -n 1 -r $FLY_REGION 2>/dev/null || true
+        run: |
+          flyctl volume create vaultwarden -y -n 1 -r $FLY_REGION 2>/dev/null || true
       - name: exports secrets
-        run: env | grep ^APP_ | sed 's/^APP_//g' | flyctl secrets import --stage
+        run: |
+          env | grep ^APP_ | sed 's/^APP_//g' | flyctl secrets import --stage
       - name: deploy app
-        run: flyctl deploy --yes --remote-only --regions $FLY_REGION
+        run: |
+          flyctl deploy --yes --remote-only

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # LiteStream versioned image
-FROM litestream/litestream:0.3 AS litestream
+FROM litestream/litestream:0.5.2 AS litestream
 
 # Vaultwarden
 FROM vaultwarden/server:latest

--- a/docker/litestream.generate.sh
+++ b/docker/litestream.generate.sh
@@ -19,8 +19,8 @@ access-key-id:      ${S3_ACCESS_KEY_ID}
 secret-access-key:  ${S3_SECRET_ACCESS_KEY}
 dbs:
 - path:             /data/db.sqlite3
-  replicas:
-  - type:           s3
+  replica:
+    type:           s3
     bucket:         ${S3_BUCKET}
     path:           ${S3_PATH}
     endpoint:       ${S3_ENDPOINT}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade Litestream and its config, modernize Fly.io deploy workflow, and set project indent to 2 spaces.
> 
> - **Docker**:
>   - Update `docker/Dockerfile` to use `litestream/litestream:0.5.2`.
>   - Adjust `docker/litestream.generate.sh` to use `replica` (singular) config format for S3.
> - **CI/CD (GitHub Actions)**:
>   - Update runner to `ubuntu-24.04`.
>   - Bump `actions/checkout` to `v6` with `fetch-depth: 1`.
>   - Pin `superfly/flyctl-actions/setup-flyctl@1.5` and Flyctl `version: 0.3.226`.
>   - Split secret preparation and override steps; streamline deploy (remove explicit `--regions`).
> - **Tooling**:
>   - Set `indent_size` to `2` in `.editorconfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0edff2824e018a664efae69a8d09a93998cae1a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->